### PR TITLE
implement v4.0

### DIFF
--- a/src/stockman.erl
+++ b/src/stockman.erl
@@ -18,8 +18,14 @@ main(["v3", InvoicesFilepath, InventoriesFilepath]) ->
     v3(Inventories, InvoicesResult),
     erlang:halt(0);
 
+main(["v4", InvoicesFilepath, InventoriesFilepath]) ->
+    Inventories = loader:load_file(inventory, InventoriesFilepath),
+    InvoicesResult = loader:load_file(invoice, InvoicesFilepath),
+    v4(Inventories, InvoicesResult),
+    erlang:halt(0);
+
 main(_) ->
-    io:format("~nusage:    v1|v2|v3  INVOICES_CSV [INVENTORY_CSV]").
+    io:format("~nusage:    v1|v2|v3|v4  INVOICES_CSV [INVENTORY_CSV]").
 
 
 v1(Invoices) ->
@@ -75,11 +81,27 @@ v2(Invoices) ->
     end.
 
 v3(Inventories, #{invoices := InvoicesToImport, load_order := Order}) ->
-    {_, _, Errors} = sales:save_invoices(
-                       #{to_save => InvoicesToImport, order => Order,
-                         inventories => Inventories, saved => dict:new()}),
+    {_, _, Errors} =
+        sales:save_invoices(
+          #{to_save => InvoicesToImport,
+            order => Order,
+            inventories => Inventories,
+            saved => dict:new()}),
     lists:foreach(fun(#{invoice := Invoice, line_no := LineNo}) ->
                           io:format("Line No: ~B~n", [LineNo]),
                           printer:pprint(Invoice)
                   end,
-                 Errors).
+                  Errors).
+
+v4(Inventories, #{invoices := InvoicesToImport}) ->
+    {_, _, Errors} =
+        sales:save_invoices(
+          #{to_save => InvoicesToImport,
+            order => ascending_timestamp,
+            inventories => Inventories,
+            saved => dict:new()}),
+    lists:foreach(fun(#{invoice := Invoice, line_no := LineNo}) ->
+                          io:format("Line No: ~B~n", [LineNo]),
+                          printer:pprint(Invoice)
+                  end,
+                  Errors).


### PR DESCRIPTION
1. Read a CSV file into memory which contains product inventory.
2. Read a CSV file into memory which contain sales invoice lines, where each invoice has a timestamp denoting the transaction date and time.
  3. Check if the product referenced on each line has enough inventory.
    4. If no, do not import the invoice to which the line belongs.
    5. If yes, import the invoice line and update the inventory of the product
       accordingly.
  6. It is important to process any given invoice only once all the other invoices with earlier timestamps have been processed.
7. Print a list of invoices listing the problematic line(s) for each invoice.
